### PR TITLE
Added new functionality, new attribute, and new default config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,23 @@ Authorization query for a given 'username':
   the numeric user identifier for the TACACS+ authenticated user on the
   host.
 
+  In the /etc/tacplus.conf file, if "default-hashed-uid" is set to "yes",
+  then a default UID will be hashed from the username, and it will be used
+  if no UID is received from the server.  The hashed UID is not guaranteed
+  to be unique, but it should be for most cases.
+
 * `gid`
 
-  The group identifier or the TACACS+ authenticated user on the host.
+  The group identifier of the TACACS+ authenticated user on the host.
+
+  Either `gid` or `group` is needed, but not both.
+
+* `group`
+
+  The group name of the TACACS+ authenticated user on the host.  The group
+  name will be converted to GID on the local system.
+
+  Either `gid` or `group` is needed, but not both.
 
 * `home`
 
@@ -94,6 +108,11 @@ Authorization query for a given 'username':
       This should be used for users in the 'qns-ro' group
       (`gid=505`)
 
+  In the /etc/tacplus.conf file, if "default-home" is set, then it will be
+  used if no HOME is received from the server.  For example, if
+  "default-home" is set to "/home", then the user's home will be
+  /home/<username>
+
 * `shell`
 
   The system-level login shell of the user. This can be any of the
@@ -110,6 +129,9 @@ Authorization query for a given 'username':
 
   The `/usr/bin/sudosh` shell can be used to audit user's activity
   on the system. 
+
+  In the /etc/tacplus.conf file, if "default-shell" is set, then it will be
+  used if no SHELL is received from the server.
 
 ## Using TACACS+ NSS module
 

--- a/etc/tacplus.conf
+++ b/etc/tacplus.conf
@@ -7,3 +7,15 @@ protocol ssh
 default-hashed-uid yes
 default-home /home
 default-shell /bin/bash
+
+# mapped-group <remote group> <local group>
+# mapped-shell <remote group> <shell>
+
+# Sample mappings
+mapped-group calea lioper
+mapped-shell calea /bin/confd_cli
+mapped-group full-access admin
+mapped-shell full-access /bin/confd_cli confd
+mapped-group maint maint
+mapped-shell maint /bin/bash
+

--- a/etc/tacplus.conf
+++ b/etc/tacplus.conf
@@ -4,3 +4,6 @@ timeout 2
 debug 1
 service linuxlogin
 protocol ssh
+default-hashed-uid yes
+default-home /home
+default-shell /bin/bash

--- a/src/nss_tacplus.c
+++ b/src/nss_tacplus.c
@@ -344,6 +344,7 @@ static enum nss_status _parse_config(char *buffer, size_t buflen)
                 // allocate new entry
                 struct tacplus_server_st *ts = (struct tacplus_server_st*)
                     malloc(sizeof(struct tacplus_server_st));
+                assert(NULL != ts);
                 ts->server = server;
                 ts->secret = secret;
                 ts->next = NULL;
@@ -518,6 +519,7 @@ static enum nss_status _parse_config(char *buffer, size_t buflen)
             // allocate new entry
             struct tacplus_group_map_st *ts = (struct tacplus_group_map_st*)
                 malloc(sizeof(struct tacplus_group_map_st));
+            assert(NULL != ts);
             ts->remote_group = remote_group;
             ts->local_group = local_group;
             ts->next = NULL;
@@ -587,6 +589,7 @@ static enum nss_status _parse_config(char *buffer, size_t buflen)
             // allocate new entry
             struct tacplus_shell_map_st *ts = (struct tacplus_shell_map_st*)
                 malloc(sizeof(struct tacplus_shell_map_st));
+            assert(NULL != ts);
             ts->remote_group = remote_group;
             ts->shell = shell;
             ts->next = NULL;
@@ -968,6 +971,7 @@ static int _passwd_from_reply(const struct areply *reply, const char *name,
                      (NULL != G_tacplus_conf.default_home))
             {
                 char *dir = (char*) malloc(sizeof(char)*80);
+                assert(NULL != dir);
                 sprintf(dir, "%s/%s", G_tacplus_conf.default_home, pw->pw_name);
                 pw->pw_dir = dir;
             }

--- a/src/nss_tacplus.c
+++ b/src/nss_tacplus.c
@@ -791,6 +791,15 @@ enum nss_status _nss_tacplus_getpwnam_r(const char *name, struct passwd *pw,
     time_t now = -1;
     uint32_t cycle = 0;
 
+    // If user is "*" or "%q", exit immediately, as this causes hanging on
+    // the command line with tab completion if any of the tacacs+ servers
+    // are down.  "*" is seen for normal bash tab competion and "%q" is
+    // seen when "~" (home dir shortcut) is part of the tab completion.
+    if ((0 == strcmp(name, "*")) || (0 == strcmp(name, "%q")))
+    {
+        return status;
+    }
+
     (void)pthread_once(&G_tacplus_initialized, &_initalize_tacplus);
     now = time(NULL);
 


### PR DESCRIPTION
- Allow a unique secret per server
- Added a new "group" attribute that allows the server config to
  specify the group by name instead of GID.
- New default config allows for minimal TACACS+ server config per user
    - Defaults are used if the TACACS+ reply doesn't include, UID, HOME,
      or SHELL
    - default-hashed-uid
        - If "yes", a default UID is hashed from username
            - Not guaranteed to be unique, but should be for most cases
    - default-home
        - If set, this is used as the default home prefix
            - Ex: "/home" would set the user's home to /home/<username>
    - default-shell
        - If set, this is used as the default shell
- Updated README.md and etc/tacplus.conf with info on new options